### PR TITLE
Copy I3D Parameters

### DIFF
--- a/i3d_exporter_additionals/__init__.py
+++ b/i3d_exporter_additionals/__init__.py
@@ -22,6 +22,8 @@ _needs_reload = "bpy" in locals()
 from . import properties, ui
 from .tools import (
     align_hydraulic_pair,
+    copy_i3d_parameters,
+    decal_adjust_offsets,
     generate_empty_on_curves,
     giants_to_i3dio,
     material_tools,
@@ -40,6 +42,8 @@ if _needs_reload:
         ui,
         properties,
         align_hydraulic_pair,
+        copy_i3d_parameters,
+        decal_adjust_offsets,
         orientation_tools,
         material_tools,
         mesh_tools,
@@ -56,6 +60,7 @@ if _needs_reload:
 def register() -> None:
     properties.register()
     align_hydraulic_pair.register()
+    decal_adjust_offsets.register()
     track_tools.register()
     verifier.register()
     generate_empty_on_curves.register()
@@ -63,6 +68,7 @@ def register() -> None:
     skeletons.register()
     material_tools.register()
     orientation_tools.register()
+    copy_i3d_parameters.register()
     user_attributes.register()
     giants_to_i3dio.register()
     ui.register()
@@ -72,6 +78,7 @@ def unregister() -> None:
     ui.unregister()
     giants_to_i3dio.unregister()
     user_attributes.unregister()
+    copy_i3d_parameters.unregister()
     orientation_tools.unregister()
     material_tools.unregister()
     skeletons.unregister()
@@ -79,6 +86,7 @@ def unregister() -> None:
     generate_empty_on_curves.unregister()
     verifier.unregister()
     track_tools.unregister()
+    decal_adjust_offsets.unregister()
     align_hydraulic_pair.unregister()
     properties.unregister()
 

--- a/i3d_exporter_additionals/blender_manifest.toml
+++ b/i3d_exporter_additionals/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "i3d_exporter_additionals"
-version = "0.0.0"
+version = "3.9.0-dev.6"
 name = "I3D Exporter Additionals"
 tagline = "Additional tools for the I3D Exporter"
 maintainer = "[NMC]T-Bone"

--- a/i3d_exporter_additionals/tools/copy_i3d_parameters.py
+++ b/i3d_exporter_additionals/tools/copy_i3d_parameters.py
@@ -1,0 +1,118 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+# copy_i3d_parameters.py - Copies every Community I3D Exporter (i3dio) specific parameter
+# from the active object (and, where applicable, its object data) to all other selected objects.
+
+import bpy
+
+from ..helper_functions import check_i3d_exporter_type
+
+# PropertyGroups (attached directly to the Object) that hold i3dio specific settings.
+# Every simple property inside these groups gets copied verbatim.
+OBJECT_PROPERTY_GROUPS = (
+    "i3d_attributes",  # General I3D Object Attributes (rigidbody, visibility condition, joints, etc.)
+    "i3d_mapping",  # I3D Mapping (is_mapped / mapping_name)
+    "i3d_reference",  # Reference File (path / runtime_loaded / child_path)
+    "i3d_merge_children",  # Merge Children (enabled / apply_transforms / interpolation_steps / reverse_order)
+    "i3d_motion_path_array",  # Motion Path Array and all of its sub settings (use_geometry_nodes, etc.)
+)
+
+# Plain properties stored directly on the Object (not inside a PropertyGroup).
+OBJECT_DIRECT_PROPERTIES = (
+    "i3d_merge_group_index",  # Merge Group membership (index into scene.i3dio_merge_groups)
+)
+
+
+def _copy_property_group(source: bpy.types.PropertyGroup, target: bpy.types.PropertyGroup) -> None:
+    """Copies every simple (non-collection, non-readonly) property from one PropertyGroup to another."""
+    for prop in source.bl_rna.properties:
+        identifier = prop.identifier
+        if identifier == "rna_type" or prop.is_readonly or prop.type == "COLLECTION":
+            continue
+        try:
+            setattr(target, identifier, getattr(source, identifier))
+        except (AttributeError, TypeError, ValueError):
+            continue  # Some properties may refuse a value (e.g. a pointer poll() rejecting it), just skip those
+
+
+def _copy_data_attributes(source_obj: bpy.types.Object, target_obj: bpy.types.Object) -> bool:
+    """Copies i3d_attributes stored on the object data (Mesh shape / Bounding Volume, or Light attributes).
+
+    Only copied when both objects share the same data type (e.g. both MESH or both LIGHT),
+    since the attributes themselves live on the data-block, not the object.
+    """
+    if source_obj.type != target_obj.type:
+        return False
+    if source_obj.type not in {"MESH", "LIGHT"}:
+        return False
+    if not hasattr(source_obj.data, "i3d_attributes") or not hasattr(target_obj.data, "i3d_attributes"):
+        return False
+    _copy_property_group(source_obj.data.i3d_attributes, target_obj.data.i3d_attributes)
+    return True
+
+
+class I3DEA_OT_copy_i3d_parameters(bpy.types.Operator):
+    bl_idname = "i3dea.copy_i3d_parameters"
+    bl_label = "Copy I3D Parameters"
+    bl_description = (
+        "Copies every Community I3D Exporter (i3dio) specific parameter from the active object "
+        "to all other selected objects.\n"
+        "Includes I3D Object Attributes, Merge Group, Merge Children, Mapping, Reference File and "
+        "Motion Path Array (with all its sub settings, e.g. Use Geometry Nodes).\n"
+        "If both objects are of the same type (Mesh or Light), the object data attributes "
+        "(e.g. Bounding Volume, Shape/Light Attributes) are copied as well"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context: bpy.types.Context) -> bool:
+        return (
+            check_i3d_exporter_type()[1]  # Only makes sense with the Community (i3dio) exporter
+            and context.active_object is not None
+            and len(context.selected_objects) > 1
+        )
+
+    def execute(self, context: bpy.types.Context):
+        active = context.active_object
+        targets = [obj for obj in context.selected_objects if obj is not active]
+        if not targets:
+            self.report({"ERROR"}, "Select at least one other object in addition to the active object")
+            return {"CANCELLED"}
+
+        data_copied_count = 0
+        for obj in targets:
+            for group_name in OBJECT_PROPERTY_GROUPS:
+                _copy_property_group(getattr(active, group_name), getattr(obj, group_name))
+
+            for prop_name in OBJECT_DIRECT_PROPERTIES:
+                setattr(obj, prop_name, getattr(active, prop_name))
+
+            if _copy_data_attributes(active, obj):
+                data_copied_count += 1
+
+        self.report(
+            {"INFO"},
+            f"Copied I3D parameters from '{active.name}' to {len(targets)} object(s) "
+            f"({data_copied_count} also received matching object-data attributes).",
+        )
+        return {"FINISHED"}
+
+
+classes = (I3DEA_OT_copy_i3d_parameters,)
+register, unregister = bpy.utils.register_classes_factory(classes)

--- a/i3d_exporter_additionals/ui.py
+++ b/i3d_exporter_additionals/ui.py
@@ -64,9 +64,10 @@ def draw_general_tools(
         grid.operator("i3dea.remove_doubles", text="Clean Meshes")
         grid.operator("i3dea.mesh_name", text="Set Mesh Name")
         grid.operator("i3dea.align_hydraulic_pair")
-        # grid.operator("i3dea.fill_volume", text="Check Fill Volume") hidden for now
+        grid.operator("i3dea.adjust_decal_offsets", text="Adjust Decal Offsets...")
+        if i3dio_enabled:
+            grid.operator("i3dea.copy_i3d_parameters", text="Copy I3D Parameters")
         if giants_enabled:
-            grid.operator("i3dea.xml_config", text="Enable export to i3dMappings")
             grid.operator("i3dea.ignore", text="Add Suffix _ignore")
             grid.operator("i3dea.verify_scene", text="Verify Scene")
             grid.operator("i3dea.convert_skinnedmesh", text="Convert SkinnedMesh")
@@ -114,21 +115,16 @@ def draw_material_tools(layout: bpy.types.UILayout, context: bpy.types.Context) 
         col = box.column(align=True)
         col.label(text="Material operators")
         row = col.row(align=True)
-        row.operator("i3dea.mirror_material", text="Add Mirror Material")
-        row.operator("i3dea.remove_unused_material_slots")
+        row.operator("i3dea.mirror_material")
 
         box = panel.box()
         box.label(text="Create Material")
         col = box.column()
         col.use_property_split = True
         col.use_property_decorate = False
-        row = col.row(align=True)
-        row.prop(i3dea, "diffuse_box")
-        if i3dea.diffuse_box:
-            row.prop(i3dea, "alpha_box")
+        col.prop(i3dea, "alpha_box")
         col.prop(i3dea, "material_name")
-        if i3dea.diffuse_box:
-            col.prop(i3dea, "diffuse_texture_path")
+        col.prop(i3dea, "diffuse_texture_path")
         col.prop(i3dea, "spec_texture_path")
         col.prop(i3dea, "normal_texture_path")
         col.operator("i3dea.setup_material", text=f"Create {i3dea.material_name}")


### PR DESCRIPTION
# Branch: Copy I3D Parameters

Base: `I3D-Exporter-Additionals-dev` (clean, unmodified baseline). Independent of the other feature branches (the Geometry Nodes Copy branch depends on this one - see that branch's `_PR_NOTES.md`).

## What this branch changes
These files differ from the baseline `i3d_exporter_additionals/` folder:

- `i3d_exporter_additionals/blender_manifest.toml`
  - Bumped `version` from `0.0.0` to `3.9.0-dev.6`. Intentional version bump for this release, flagged explicitly since a previous combined PR got called out for touching the manifest unintentionally.

- `i3d_exporter_additionals/tools/copy_i3d_parameters.py` (new file)
  - `I3DEA_OT_copy_i3d_parameters` operator (`i3dea.copy_i3d_parameters`) that copies every Community I3D Exporter (i3dio) specific parameter from the active object to all other selected objects:
    - `i3d_attributes` (rigidbody, visibility conditions, joints, LOD, etc.)
    - `i3d_mapping`, `i3d_reference`
    - `i3d_merge_children`
    - `i3d_motion_path_array` - including all sub settings (e.g. Use Geometry Nodes, cyclic, include position/rotation/scale, hide first/last)
    - `i3d_merge_group_index` (joins the same Merge Group as the active object)
    - If both objects are the same type (Mesh<->Mesh or Light<->Light), also copies the object-**data** attributes (e.g. Bounding Volume, shape flags, or light attributes).
  - Uses a generic reflection-based copy helper (`_copy_property_group`) that walks each PropertyGroup's `bl_rna.properties`, so any future property added to these groups is picked up automatically.
- `i3d_exporter_additionals/__init__.py`
  - Imports the new `copy_i3d_parameters` module and registers/unregisters it alongside the other tools.
- `i3d_exporter_additionals/ui.py`
  - In "General Tools", added the "Copy I3D Parameters" button (only shown when the Community/i3dio exporter is detected as enabled).