### PR TITLE
Enable All Material Slotnames

### DIFF
--- a/i3d_exporter_additionals/blender_manifest.toml
+++ b/i3d_exporter_additionals/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "i3d_exporter_additionals"
-version = "0.0.0"
+version = "3.9.0-dev.6"
 name = "I3D Exporter Additionals"
 tagline = "Additional tools for the I3D Exporter"
 maintainer = "[NMC]T-Bone"

--- a/i3d_exporter_additionals/blender_manifest.toml
+++ b/i3d_exporter_additionals/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "i3d_exporter_additionals"
-version = "3.9.0-dev.6"
+version = "0.0.0"
 name = "I3D Exporter Additionals"
 tagline = "Additional tools for the I3D Exporter"
 maintainer = "[NMC]T-Bone"

--- a/i3d_exporter_additionals/tools/material_tools.py
+++ b/i3d_exporter_additionals/tools/material_tools.py
@@ -156,8 +156,43 @@ class I3DEA_OT_setup_material(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class I3DEA_OT_enable_all_material_slotnames(bpy.types.Operator):
+    bl_idname = "i3dea.enable_all_material_slotnames"
+    bl_label = "Enable All Material Slot Names"
+    bl_description = (
+        "Enables 'Material Slot Name' on every material in the blend file.\n"
+        "Materials that already have it enabled keep their existing custom name.\n"
+        "Materials that get newly enabled are left blank "
+        "(the material's own name will be used on export)"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context) -> bool:
+        return check_i3d_exporter_type()[1]  # Only makes sense with the Community (i3dio) exporter
+
+    def execute(self, context: bpy.types.Context):
+        newly_enabled = 0
+        already_enabled = 0
+
+        for mat in bpy.data.materials:
+            if mat.i3d_attributes.use_material_slot_name:
+                already_enabled += 1
+                continue
+            mat.i3d_attributes.use_material_slot_name = True
+            newly_enabled += 1
+
+        self.report(
+            {"INFO"},
+            f"Enabled Material Slot Name on {newly_enabled} material(s) "
+            f"({already_enabled} already had it enabled).",
+        )
+        return {"FINISHED"}
+
+
 classes = (
     I3DEA_OT_mirror_material,
     I3DEA_OT_setup_material,
+    I3DEA_OT_enable_all_material_slotnames,
 )
 register, unregister = bpy.utils.register_classes_factory(classes)

--- a/i3d_exporter_additionals/tools/material_tools.py
+++ b/i3d_exporter_additionals/tools/material_tools.py
@@ -156,14 +156,13 @@ class I3DEA_OT_setup_material(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class I3DEA_OT_enable_all_material_slotnames(bpy.types.Operator):
-    bl_idname = "i3dea.enable_all_material_slotnames"
-    bl_label = "Enable All Material Slot Names"
+class I3DEA_OT_enable_all_material_slot_names(bpy.types.Operator):
+    bl_idname = "i3dea.enable_all_material_slot_names"
+    bl_label = "Enable Slot Names (All Materials)"
     bl_description = (
-        "Enables 'Material Slot Name' on every material in the blend file.\n"
-        "Materials that already have it enabled keep their existing custom name.\n"
-        "Materials that get newly enabled are left blank "
-        "(the material's own name will be used on export)"
+        "Enables 'Material Slot Name' for all materials in the current blend file.\n"
+        "Existing custom slot names are preserved.\n"
+        "Newly enabled materials use their material name on export"
     )
     bl_options = {"REGISTER", "UNDO"}
 
@@ -171,7 +170,7 @@ class I3DEA_OT_enable_all_material_slotnames(bpy.types.Operator):
     def poll(cls, context) -> bool:
         return check_i3d_exporter_type()[1]  # Only makes sense with the Community (i3dio) exporter
 
-    def execute(self, context: bpy.types.Context):
+    def execute(self, context):
         newly_enabled = 0
         already_enabled = 0
 
@@ -184,8 +183,7 @@ class I3DEA_OT_enable_all_material_slotnames(bpy.types.Operator):
 
         self.report(
             {"INFO"},
-            f"Enabled Material Slot Name on {newly_enabled} material(s) "
-            f"({already_enabled} already had it enabled).",
+            f"Enabled Material Slot Name on {newly_enabled} material(s) ({already_enabled} already had it enabled).",
         )
         return {"FINISHED"}
 
@@ -193,6 +191,6 @@ class I3DEA_OT_enable_all_material_slotnames(bpy.types.Operator):
 classes = (
     I3DEA_OT_mirror_material,
     I3DEA_OT_setup_material,
-    I3DEA_OT_enable_all_material_slotnames,
+    I3DEA_OT_enable_all_material_slot_names,
 )
 register, unregister = bpy.utils.register_classes_factory(classes)

--- a/i3d_exporter_additionals/ui.py
+++ b/i3d_exporter_additionals/ui.py
@@ -115,7 +115,7 @@ def draw_material_tools(layout: bpy.types.UILayout, context: bpy.types.Context) 
         row = col.row(align=True)
         row.operator("i3dea.mirror_material")
         row = col.row(align=True)
-        row.operator("i3dea.enable_all_material_slotnames", icon="OUTLINER_DATA_FONT")
+        row.operator("i3dea.enable_all_material_slot_names", icon="MATERIAL")
 
         box = panel.box()
         box.label(text="Create Material")

--- a/i3d_exporter_additionals/ui.py
+++ b/i3d_exporter_additionals/ui.py
@@ -114,6 +114,8 @@ def draw_material_tools(layout: bpy.types.UILayout, context: bpy.types.Context) 
         col.label(text="Material operators")
         row = col.row(align=True)
         row.operator("i3dea.mirror_material")
+        row = col.row(align=True)
+        row.operator("i3dea.enable_all_material_slotnames", icon="OUTLINER_DATA_FONT")
 
         box = panel.box()
         box.label(text="Create Material")


### PR DESCRIPTION
# Branch: Enable All Material Slotnames

Base: `I3D-Exporter-Additionals-dev` (clean, unmodified baseline).

## What this branch changes
These files differ from the baseline `i3d_exporter_additionals/` folder:

- `i3d_exporter_additionals/blender_manifest.toml`
  - Bumped `version` from `0.0.0` to `3.9.0-dev.6`. This is an intentional version bump for this release, not an accidental side effect - flagging it explicitly since a previous combined PR got called out for touching the manifest unintentionally.

- `i3d_exporter_additionals/tools/material_tools.py`
  - Added `I3DEA_OT_enable_all_material_slotnames` operator (`i3dea.enable_all_material_slotnames`).
  - Enables `use_material_slot_name` on every material in the file that doesn't already have it on. Materials that already have it enabled are left untouched (name kept as-is). Newly-enabled materials are left with a blank custom name, so export falls back to the material's own name (see `Material.get_slot_name()` in the i3dio exporter).
  - Added the new operator to the `classes` tuple.
- `i3d_exporter_additionals/ui.py`
  - Added a button for the new operator in the "Material Tools" panel, right under "Add Mirror Material".