### PR TITLE
Geometry Nodes Copy

### DIFF
--- a/i3d_exporter_additionals/__init__.py
+++ b/i3d_exporter_additionals/__init__.py
@@ -22,6 +22,8 @@ _needs_reload = "bpy" in locals()
 from . import properties, ui
 from .tools import (
     align_hydraulic_pair,
+    copy_i3d_parameters,
+    decal_adjust_offsets,
     generate_empty_on_curves,
     giants_to_i3dio,
     material_tools,
@@ -40,6 +42,8 @@ if _needs_reload:
         ui,
         properties,
         align_hydraulic_pair,
+        copy_i3d_parameters,
+        decal_adjust_offsets,
         orientation_tools,
         material_tools,
         mesh_tools,
@@ -56,6 +60,7 @@ if _needs_reload:
 def register() -> None:
     properties.register()
     align_hydraulic_pair.register()
+    decal_adjust_offsets.register()
     track_tools.register()
     verifier.register()
     generate_empty_on_curves.register()
@@ -63,6 +68,7 @@ def register() -> None:
     skeletons.register()
     material_tools.register()
     orientation_tools.register()
+    copy_i3d_parameters.register()
     user_attributes.register()
     giants_to_i3dio.register()
     ui.register()
@@ -72,6 +78,7 @@ def unregister() -> None:
     ui.unregister()
     giants_to_i3dio.unregister()
     user_attributes.unregister()
+    copy_i3d_parameters.unregister()
     orientation_tools.unregister()
     material_tools.unregister()
     skeletons.unregister()
@@ -79,6 +86,7 @@ def unregister() -> None:
     generate_empty_on_curves.unregister()
     verifier.unregister()
     track_tools.unregister()
+    decal_adjust_offsets.unregister()
     align_hydraulic_pair.unregister()
     properties.unregister()
 

--- a/i3d_exporter_additionals/blender_manifest.toml
+++ b/i3d_exporter_additionals/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "i3d_exporter_additionals"
-version = "0.0.0"
+version = "3.9.0-dev.6"
 name = "I3D Exporter Additionals"
 tagline = "Additional tools for the I3D Exporter"
 maintainer = "[NMC]T-Bone"

--- a/i3d_exporter_additionals/properties.py
+++ b/i3d_exporter_additionals/properties.py
@@ -489,16 +489,22 @@ class I3DEA_PG_List(bpy.types.PropertyGroup):
         default="frontloaderAdapter",
     )
 
+    # Geometry Nodes
+    copy_geometry_nodes: BoolProperty(
+        name="Copy Geometry Nodes",
+        description=(
+            "When enabled, using 'Copy I3D Parameters' (General Tools) will also copy every Geometry Nodes "
+            "modifier from the active object to the selected objects (node group assignment and all input "
+            "values, matched or added by modifier name)"
+        ),
+        default=False,
+    )
+
     # Properties for material_tools
     material_name: StringProperty(
         name="Material name",
         description="Write name of the material you want to create",
         default="material_mat",
-    )
-    diffuse_box: BoolProperty(
-        name="Add diffuse node",
-        description="If checked it will create a image texture linked to Base Color",
-        default=False,
     )
     alpha_box: BoolProperty(
         name="Alpha", description="If checked it will set alpha settings to diffuse node", default=False
@@ -520,38 +526,6 @@ class I3DEA_PG_List(bpy.types.PropertyGroup):
         description="Add path to your normal map texture.",
         subtype="FILE_PATH",
         default="",
-    )
-
-    # i3dio_material handler
-    shader_path: StringProperty(
-        name="Path to shader location",
-        description="Select path to the shader you want to apply",
-        subtype="FILE_PATH",
-        default="",
-    )
-    mask_map: StringProperty(
-        name="Mask Map",
-        description="Add mask map texture",
-        subtype="FILE_PATH",
-        default="",
-    )
-    dirt_diffuse: StringProperty(
-        name="Dirt diffuse", description="Add dirt diffuse texture", subtype="FILE_PATH", default=""
-    )
-    shader_box: BoolProperty(
-        name="Set shader path",
-        description="If checked it will add the the path to the shader in material",
-        default=True,
-    )
-    mask_map_box: BoolProperty(
-        name="Set mask map path",
-        description="If checked it will add the the path to mask map in material",
-        default=True,
-    )
-    dirt_diffuse_box: BoolProperty(
-        name="Set dirt diffuse path",
-        description="If checked it add the the path to dirt diffuse in material",
-        default=True,
     )
 
     # Track-Tools

--- a/i3d_exporter_additionals/tools/copy_i3d_parameters.py
+++ b/i3d_exporter_additionals/tools/copy_i3d_parameters.py
@@ -1,0 +1,152 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+# copy_i3d_parameters.py - Copies every Community I3D Exporter (i3dio) specific parameter
+# from the active object (and, where applicable, its object data) to all other selected objects.
+# Optionally also copies Geometry Nodes modifiers, see "copy_geometry_nodes" in properties.py.
+
+import bpy
+
+from ..helper_functions import check_i3d_exporter_type
+
+# PropertyGroups (attached directly to the Object) that hold i3dio specific settings.
+# Every simple property inside these groups gets copied verbatim.
+OBJECT_PROPERTY_GROUPS = (
+    "i3d_attributes",  # General I3D Object Attributes (rigidbody, visibility condition, joints, etc.)
+    "i3d_mapping",  # I3D Mapping (is_mapped / mapping_name)
+    "i3d_reference",  # Reference File (path / runtime_loaded / child_path)
+    "i3d_merge_children",  # Merge Children (enabled / apply_transforms / interpolation_steps / reverse_order)
+    "i3d_motion_path_array",  # Motion Path Array and all of its sub settings (use_geometry_nodes, etc.)
+)
+
+# Plain properties stored directly on the Object (not inside a PropertyGroup).
+OBJECT_DIRECT_PROPERTIES = (
+    "i3d_merge_group_index",  # Merge Group membership (index into scene.i3dio_merge_groups)
+)
+
+
+def _copy_property_group(source: bpy.types.PropertyGroup, target: bpy.types.PropertyGroup) -> None:
+    """Copies every simple (non-collection, non-readonly) property from one PropertyGroup to another."""
+    for prop in source.bl_rna.properties:
+        identifier = prop.identifier
+        if identifier == "rna_type" or prop.is_readonly or prop.type == "COLLECTION":
+            continue
+        try:
+            setattr(target, identifier, getattr(source, identifier))
+        except (AttributeError, TypeError, ValueError):
+            continue  # Some properties may refuse a value (e.g. a pointer poll() rejecting it), just skip those
+
+
+def _copy_data_attributes(source_obj: bpy.types.Object, target_obj: bpy.types.Object) -> bool:
+    """Copies i3d_attributes stored on the object data (Mesh shape / Bounding Volume, or Light attributes).
+
+    Only copied when both objects share the same data type (e.g. both MESH or both LIGHT),
+    since the attributes themselves live on the data-block, not the object.
+    """
+    if source_obj.type != target_obj.type:
+        return False
+    if source_obj.type not in {"MESH", "LIGHT"}:
+        return False
+    if not hasattr(source_obj.data, "i3d_attributes") or not hasattr(target_obj.data, "i3d_attributes"):
+        return False
+    _copy_property_group(source_obj.data.i3d_attributes, target_obj.data.i3d_attributes)
+    return True
+
+
+def _copy_geometry_nodes_modifiers(
+    context: bpy.types.Context, source_obj: bpy.types.Object, target_obj: bpy.types.Object
+) -> int:
+    """Copies every Geometry Nodes modifier from source_obj to target_obj.
+
+    Uses Blender's built-in "Copy to Selected" modifier behavior (the same operator behind the
+    modifier dropdown's "Copy to Selected" entry), so the node group assignment and every input
+    value (including driven/animated ones) come along, matched or added by modifier name.
+    """
+    gn_modifiers = [mod for mod in source_obj.modifiers if mod.type == "NODES"]
+    if not gn_modifiers:
+        return 0
+
+    copied = 0
+    for mod in gn_modifiers:
+        try:
+            with context.temp_override(object=source_obj, selected_editable_objects=[target_obj]):
+                bpy.ops.object.modifier_copy_to_selected(modifier=mod.name)
+            copied += 1
+        except RuntimeError:
+            continue  # e.g. target object type doesn't support modifiers/this modifier type
+    return copied
+
+
+class I3DEA_OT_copy_i3d_parameters(bpy.types.Operator):
+    bl_idname = "i3dea.copy_i3d_parameters"
+    bl_label = "Copy I3D Parameters"
+    bl_description = (
+        "Copies every Community I3D Exporter (i3dio) specific parameter from the active object "
+        "to all other selected objects.\n"
+        "Includes I3D Object Attributes, Merge Group, Merge Children, Mapping, Reference File and "
+        "Motion Path Array (with all its sub settings, e.g. Use Geometry Nodes).\n"
+        "If both objects are of the same type (Mesh or Light), the object data attributes "
+        "(e.g. Bounding Volume, Shape/Light Attributes) are copied as well.\n"
+        "If 'Copy Geometry Nodes' (Geometry Nodes panel) is enabled, Geometry Nodes modifiers are "
+        "copied too"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context: bpy.types.Context) -> bool:
+        return (
+            check_i3d_exporter_type()[1]  # Only makes sense with the Community (i3dio) exporter
+            and context.active_object is not None
+            and len(context.selected_objects) > 1
+        )
+
+    def execute(self, context: bpy.types.Context):
+        active = context.active_object
+        targets = [obj for obj in context.selected_objects if obj is not active]
+        if not targets:
+            self.report({"ERROR"}, "Select at least one other object in addition to the active object")
+            return {"CANCELLED"}
+
+        copy_geometry_nodes = context.scene.i3dea.copy_geometry_nodes
+        data_copied_count = 0
+        geo_nodes_copied_count = 0
+        for obj in targets:
+            for group_name in OBJECT_PROPERTY_GROUPS:
+                _copy_property_group(getattr(active, group_name), getattr(obj, group_name))
+
+            for prop_name in OBJECT_DIRECT_PROPERTIES:
+                setattr(obj, prop_name, getattr(active, prop_name))
+
+            if _copy_data_attributes(active, obj):
+                data_copied_count += 1
+
+            if copy_geometry_nodes:
+                geo_nodes_copied_count += _copy_geometry_nodes_modifiers(context, active, obj)
+
+        message = (
+            f"Copied I3D parameters from '{active.name}' to {len(targets)} object(s) "
+            f"({data_copied_count} also received matching object-data attributes)."
+        )
+        if copy_geometry_nodes:
+            message += f" Copied {geo_nodes_copied_count} Geometry Nodes modifier(s)."
+        self.report({"INFO"}, message)
+        return {"FINISHED"}
+
+
+classes = (I3DEA_OT_copy_i3d_parameters,)
+register, unregister = bpy.utils.register_classes_factory(classes)

--- a/i3d_exporter_additionals/ui.py
+++ b/i3d_exporter_additionals/ui.py
@@ -47,6 +47,8 @@ class I3DEA_PT_MainPanel(Panel):
             draw_user_attributes(layout, context)
         draw_skeletons(layout, context)
         draw_material_tools(layout, context)
+        if i3dio_enabled:
+            draw_geometry_nodes(layout, context)
         draw_track_tools(layout, context)
         draw_motion_path(layout, context)
 
@@ -64,9 +66,10 @@ def draw_general_tools(
         grid.operator("i3dea.remove_doubles", text="Clean Meshes")
         grid.operator("i3dea.mesh_name", text="Set Mesh Name")
         grid.operator("i3dea.align_hydraulic_pair")
-        # grid.operator("i3dea.fill_volume", text="Check Fill Volume") hidden for now
+        grid.operator("i3dea.adjust_decal_offsets", text="Adjust Decal Offsets...")
+        if i3dio_enabled:
+            grid.operator("i3dea.copy_i3d_parameters", text="Copy I3D Parameters")
         if giants_enabled:
-            grid.operator("i3dea.xml_config", text="Enable export to i3dMappings")
             grid.operator("i3dea.ignore", text="Add Suffix _ignore")
             grid.operator("i3dea.verify_scene", text="Verify Scene")
             grid.operator("i3dea.convert_skinnedmesh", text="Convert SkinnedMesh")
@@ -114,24 +117,30 @@ def draw_material_tools(layout: bpy.types.UILayout, context: bpy.types.Context) 
         col = box.column(align=True)
         col.label(text="Material operators")
         row = col.row(align=True)
-        row.operator("i3dea.mirror_material", text="Add Mirror Material")
-        row.operator("i3dea.remove_unused_material_slots")
+        row.operator("i3dea.mirror_material")
 
         box = panel.box()
         box.label(text="Create Material")
         col = box.column()
         col.use_property_split = True
         col.use_property_decorate = False
-        row = col.row(align=True)
-        row.prop(i3dea, "diffuse_box")
-        if i3dea.diffuse_box:
-            row.prop(i3dea, "alpha_box")
+        col.prop(i3dea, "alpha_box")
         col.prop(i3dea, "material_name")
-        if i3dea.diffuse_box:
-            col.prop(i3dea, "diffuse_texture_path")
+        col.prop(i3dea, "diffuse_texture_path")
         col.prop(i3dea, "spec_texture_path")
         col.prop(i3dea, "normal_texture_path")
         col.operator("i3dea.setup_material", text=f"Create {i3dea.material_name}")
+
+
+def draw_geometry_nodes(layout: bpy.types.UILayout, context: bpy.types.Context) -> None:
+    header, panel = layout.panel("I3DEA_geometry_nodes", default_closed=True)
+    header.label(text="Geometry Nodes")
+    if panel:
+        i3dea = context.scene.i3dea
+        col = panel.column(align=True)
+        col.prop(i3dea, "copy_geometry_nodes")
+        col.label(text="Also copies Geometry Nodes modifiers when using")
+        col.label(text="'Copy I3D Parameters' in General Tools.")
 
 
 def draw_track_tools(layout: bpy.types.UILayout, context: bpy.types.Context) -> None:


### PR DESCRIPTION
# Branch: Geometry Nodes Copy (Dependent on #50)

**Depends on:** `I3D-Exporter-Additionals-dev-Copy-I3D-Parameters` (this branch's `tools/copy_i3d_parameters.py` is that branch's file, extended). Build/PR this one *after* "Copy I3D Parameters" has been merged (or rebase this branch onto it) — it is not meant to stand alone against clean `dev`.

Base: `I3D-Exporter-Additionals-dev` (clean, unmodified baseline), plus the Copy I3D Parameters feature.

## What this branch changes (on top of Copy I3D Parameters) Note: `blender_manifest.toml` here is identical to the Copy I3D Parameters branch's manifest (version `3.9.0-dev.6`) - it is not an additional bump introduced by this PR, just inherited from the branch this one is built on top of. Nothing to point out to a reviewer beyond what's already covered in that PR.

- `i3d_exporter_additionals/properties.py`
  - Added `copy_geometry_nodes` (BoolProperty, default `False`) under a new "Geometry Nodes" section.
- `i3d_exporter_additionals/tools/copy_i3d_parameters.py`
  - Added `_copy_geometry_nodes_modifiers()` — copies every Geometry Nodes modifier from the active object to a target object using Blender's built-in "Copy to Selected" modifier behavior (`bpy.ops.object.modifier_copy_to_selected`), so the node group assignment and all input values (including driven/animated ones) come along, matched or added by modifier name.
  - `I3DEA_OT_copy_i3d_parameters.execute()` now also runs that copy per target object when `scene.i3dea.copy_geometry_nodes` is enabled, and reports how many modifiers were copied.
- `i3d_exporter_additionals/ui.py`
  - Added a new top-level panel category "Geometry Nodes" (`draw_geometry_nodes`) with the `copy_geometry_nodes` checkbox, only shown when the Community (i3dio) exporter is detected.
  - `I3DEA_PT_MainPanel.draw()` calls the new `draw_geometry_nodes()` alongside the other sections.

## Behavior
- Checkbox defaults to **off**. When on, pressing "Copy I3D Parameters" (General Tools) also copies any Geometry Nodes modifiers from the active object to the selected objects.
- If the active object has no Geometry Nodes modifiers, nothing extra happens (0 copied, reported as such).